### PR TITLE
Script to create tokens for flocking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
 
 COPY supervisord.conf /etc/supervisord.conf
 COPY condor/*.conf /etc/condor/config.d/
-COPY start.sh update-config update-secrets /
+COPY start.sh update-config update-secrets create-flocking-tokens /
 COPY fetch-crl.cron /etc/cron.d/fetch-crl
 
 CMD ["/bin/bash", "-x", "/start.sh"]

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build:
 run:
 	-mkdir -p config/
 	-mkdir -p secrets/
-	-docker run --rm -v config:/root/config:ro -v secrets:/root/secrets:ro --name $(NAMESPACE)_submit_host $(NAMESPACE)/submit-host
+	-docker run --rm -v `pwd`/config:/root/config:ro -v `pwd`/secrets:/root/secrets:ro --name $(NAMESPACE)_submit_host $(NAMESPACE)/submit-host
 
 
 .PHONY: clean

--- a/create-flocking-tokens
+++ b/create-flocking-tokens
@@ -40,7 +40,8 @@ if [[ ! -e $key_file ]]; then
     exit 0
 fi
 
-echo "Generating flocking tokens from $key_file"
+printf "%s\n" "-------------------------------------------------------------------------------"
+echo "*** Generating flocking tokens from $key_file ***"
 
 sec_token_directory=$(condor_config_val SEC_TOKEN_DIRECTORY 2>/dev/null || echo "$HOME/.condor/tokens.d")
 
@@ -58,3 +59,5 @@ for host in ${flock_from[*]}; do
     fi
 done
 umask 022
+
+printf "%s\n" "..............................................................................."

--- a/create-flocking-tokens
+++ b/create-flocking-tokens
@@ -20,8 +20,8 @@ if [[ $1 == -f ]]; then
     shift
 fi
 
-read -ra flock_from <(condor_config_val FLOCK_FROM 2>/dev/null)
-if [[ ${#flock_from[*]} -eq 0 ]]; then
+flock_from=$(condor_config_val FLOCK_FROM 2>/dev/null)
+if [[ ${#flock_from} -eq 0 ]]; then
     echo "No flocking hosts"
     echo "Not generating tokens"
     exit 0
@@ -46,7 +46,7 @@ echo "*** Generating flocking tokens from $key_file ***"
 sec_token_directory=$(condor_config_val SEC_TOKEN_DIRECTORY 2>/dev/null || echo "$HOME/.condor/tokens.d")
 
 umask 077
-for host in ${flock_from[*]}; do
+for host in $flock_from; do
     id=condor@$host
     newfile=$sec_token_directory/$id
     if [[ ! -e $newfile ]] || $force; then

--- a/create-flocking-tokens
+++ b/create-flocking-tokens
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Usage:
+#
+#    create-flocking-tokens [-f] [<keyid>]
+#
+# Creates tokens for all of the hosts in the FLOCK_FROM list.
+# The tokens don't expire and don't have extra priv restrictions on them.
+# Does not create tokens that already exist unless '-f' is passed.
+#
+# If keyid is not specified, will use the pool password (SEC_PASSWORD_FILE).
+#
+# Does not create tokens if the key file doesn't exist, or if there are
+# no hosts in FLOCK_FROM.
+
+
+force=false
+if [[ $1 == -f ]]; then
+    force=true
+    shift
+fi
+
+read -ra flock_from <(condor_config_val FLOCK_FROM 2>/dev/null)
+if [[ ${#flock_from[*]} -eq 0 ]]; then
+    echo "No flocking hosts"
+    echo "Not generating tokens"
+    exit 0
+fi
+
+keyid_arg=
+key_file=$(condor_config_val SEC_PASSWORD_FILE)
+if [[ $1 ]]; then
+    keyid_arg=(-keyid "$1")
+    key_file=$(condor_config_val SEC_PASSWORD_DIRECTORY)/$1
+fi
+
+if [[ ! -e $key_file ]]; then
+    echo "No key file at $key_file"
+    echo "Not generating tokens"
+    exit 0
+fi
+
+echo "Generating flocking tokens from $key_file"
+
+sec_token_directory=$(condor_config_val SEC_TOKEN_DIRECTORY 2>/dev/null || echo "$HOME/.condor/tokens.d")
+
+umask 077
+for host in ${flock_from[*]}; do
+    id=condor@$host
+    newfile=$sec_token_directory/$id
+    if [[ ! -e $newfile ]] || $force; then
+        echo -n "$id (new): "
+        condor_token_create "${keyid_arg[@]}" -identity "$id" -token "$id"
+        cat "$newfile"
+    else
+        echo -n "$id: "
+        cat "$newfile"
+    fi
+done
+umask 022

--- a/create-flocking-tokens
+++ b/create-flocking-tokens
@@ -8,10 +8,12 @@
 # The tokens don't expire and don't have extra priv restrictions on them.
 # Does not create tokens that already exist unless '-f' is passed.
 #
-# If keyid is not specified, will use the pool password (SEC_PASSWORD_FILE).
+# If keyid is not specified, will use $(SEC_PASSWORD_DIRECTORY)/flock_issuer.
 #
 # Does not create tokens if the key file doesn't exist, or if there are
 # no hosts in FLOCK_FROM.
+
+DEFAULT_KEY=flock_issuer
 
 
 force=false
@@ -27,12 +29,9 @@ if [[ ${#flock_from} -eq 0 ]]; then
     exit 0
 fi
 
-keyid_arg=
-key_file=$(condor_config_val SEC_PASSWORD_FILE)
-if [[ $1 ]]; then
-    keyid_arg=(-key "$1")
-    key_file=$(condor_config_val SEC_PASSWORD_DIRECTORY)/$1
-fi
+sec_password_directory=$(condor_config_val SEC_PASSWORD_DIRECTORY 2>/dev/null)
+key=${1:-$DEFAULT_KEY}
+key_file=$sec_password_directory/$key
 
 if [[ ! -e $key_file ]]; then
     echo "No key file at $key_file"
@@ -51,7 +50,7 @@ for host in $flock_from; do
     newfile=$sec_token_directory/$id
     if [[ ! -e $newfile ]] || $force; then
         echo -n "$id (new): "
-        condor_token_create ${keyid_arg[*]} -identity "$id" -token "$id"
+        condor_token_create -key "$key" -identity "$id" -token "$id"
         cat "$newfile"
     else
         echo -n "$id: "

--- a/create-flocking-tokens
+++ b/create-flocking-tokens
@@ -30,7 +30,7 @@ fi
 keyid_arg=
 key_file=$(condor_config_val SEC_PASSWORD_FILE)
 if [[ $1 ]]; then
-    keyid_arg=(-keyid "$1")
+    keyid_arg=(-key "$1")
     key_file=$(condor_config_val SEC_PASSWORD_DIRECTORY)/$1
 fi
 
@@ -51,7 +51,7 @@ for host in $flock_from; do
     newfile=$sec_token_directory/$id
     if [[ ! -e $newfile ]] || $force; then
         echo -n "$id (new): "
-        condor_token_create "${keyid_arg[@]}" -identity "$id" -token "$id"
+        condor_token_create ${keyid_arg[*]} -identity "$id" -token "$id"
         cat "$newfile"
     else
         echo -n "$id: "

--- a/start.sh
+++ b/start.sh
@@ -23,8 +23,8 @@ add_values_to 01-env.conf \
     USE_POOL_PASSWORD "${USE_POOL_PASSWORD:-no}"
 
 
-bash -x "$progdir/update-secrets" || fail "Failed to update secrets"
 bash -x "$progdir/update-config" || fail "Failed to update config"
+bash -x "$progdir/update-secrets" || fail "Failed to update secrets"
 
 
 # Bug workaround: daemons will die if they can't raise the number of FD's;

--- a/update-secrets
+++ b/update-secrets
@@ -17,6 +17,12 @@ if [[ -f /root/secrets/pool_password ]]; then
     umask 022
 fi
 
+if [[ -d /root/secrets/passwords ]]; then
+    cp -pv /root/secrets/passwords/* /etc/condor/passwords.d
+    chown root:root /etc/condor/passwords.d/*
+    chmod 0600 /etc/condor/passwords.d/*
+fi
+
 # A token.
 if [[ -f /root/secrets/token ]]; then
     umask 077
@@ -25,6 +31,11 @@ if [[ -f /root/secrets/token ]]; then
     umask 022
 fi
 
+if [[ -d /root/secrets/tokens ]]; then
+    cp -pv /root/secrets/tokens/* /etc/condor/tokens.d
+    chown condor:condor /etc/condor/tokens.d/*
+    chmod 0600 /etc/condor/tokens.d/*
+fi
 
 bash "$progdir/create-flocking-tokens"
 

--- a/update-secrets
+++ b/update-secrets
@@ -8,11 +8,12 @@ fail () {
     exit 1
 }
 
+sec_password_file=$(condor_config_val SEC_PASSWORD_FILE 2>/dev/null || /etc/condor/POOL)
 
 # Pool password; used for PASSWORD auth or for the collector to generate tokens from.
 if [[ -f /root/secrets/pool_password ]]; then
     umask 077
-    install -o root -g root -m 0600 -D /root/secrets/pool_password /etc/condor/passwords.d/POOL ||\
+    install -o root -g root -m 0600 -D /root/secrets/pool_password "$sec_password_file" ||\
         fail "/root/secrets/pool_password found but unable to copy"
     umask 022
 fi

--- a/update-secrets
+++ b/update-secrets
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 prog=${0##*/}
+progdir=${0%/*}
 
 fail () {
     echo "$prog:" "$@" >&2
@@ -24,5 +25,7 @@ if [[ -f /root/secrets/token ]]; then
     umask 022
 fi
 
+
+bash "$progdir/create-flocking-tokens"
 
 # vim:et:sw=4:sts=4:ts=8


### PR DESCRIPTION
Runs automatically on startup and uses the pool password to generate tokens for all the hosts in FLOCK_FROM. Saves tokens to the usual place (`$HOME/.config/tokens.d`) and also prints them to stdout. When run manually, you can use a different key.