### PR TITLE
Make sure the condor UID/GID matches upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM opensciencegrid/software-base:fresh
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 
-RUN groupadd -g 1000 -r condor
+RUN groupadd -g 64 -r condor
 RUN useradd -r -g condor -d /var/lib/condor -s /sbin/nologin \
-    -u 1000 -c "Owner of HTCondor Daemons" condor
+    -u 64 -c "Owner of HTCondor Daemons" condor
 
 RUN \
  yum -y update  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM opensciencegrid/software-base:fresh
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 
+# Ensure that the 'condor' UID/GID matches across containers
+# Using the RedHat assigned UID/GID for the condor user
 RUN groupadd -g 64 -r condor
 RUN useradd -r -g condor -d /var/lib/condor -s /sbin/nologin \
     -u 64 -c "Owner of HTCondor Daemons" condor


### PR DESCRIPTION
This is causing failures in the WeNMR CE