### PR TITLE
Use NETWORK_HOSTNAME as the value for TCP_FORWARDING_HOST

### DIFF
--- a/condor/04-misc.conf
+++ b/condor/04-misc.conf
@@ -1,2 +1,6 @@
 # Can't tune the kernel in a container
 ENABLE_KERNEL_TUNING=False
+
+# Tell clients to contact the submit host on the hostname used to
+# advertise to other daemons
+TCP_FORWARDING_HOST = $(NETWORK_HOSTNAME)


### PR DESCRIPTION
This ensures that clients talking to our daemons will try to contact
us on NETWORK_HOSTNAME